### PR TITLE
Fix typo in command from 'paralellize' to 'parallelize'

### DIFF
--- a/jj_tui/bin/graph_commands.ml
+++ b/jj_tui/bin/graph_commands.ml
@@ -362,7 +362,7 @@ module Make (Vars : Global_vars.Vars) = struct
           (fun () ->
             PromptThen
               ( "list commits to parallelize"
-              , fun x -> Cmd ([ "paralellize" ] @ (x |> String.split_on_char ' ')) ))
+              , fun x -> Cmd ([ "parallelize" ] @ (x |> String.split_on_char ' ')) ))
       }
     ; {
         id = "abandon"


### PR DESCRIPTION
thank you for this lovely tool! I noticed a jj parallelize typo