### PR TITLE
Document multi-select behaviour using space key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jujutsu TUI
 [![nix](https://github.com/faldor20/jj_tui/actions/workflows/build-nix.yml/badge.svg)](https://github.com/faldor20/jj_tui/actions/workflows/build-nix.yml)
-A TUI for the new version control system Jujutsu 
+A TUI for the new version control system Jujutsu
 
 
 ![jj_tui-ezgif com-optimize](https://github.com/faldor20/jj_tui/assets/26968035/fb053320-484a-4d6f-9b66-e5b9d0d49e5d)
@@ -8,21 +8,22 @@ A TUI for the new version control system Jujutsu
 
 Press `?` to show the help. (commands are different between graph and files view).
 Press `Arrows` to navigate windows, `Enter` to focus status view
+Press `Space` to select/deselect revisions (multi-select in graph view)
 List of graph commands:
 
 ![jj_tui commands](https://github.com/user-attachments/assets/1e446a3d-1736-4207-b311-29d8e4bdc333)
 
-Please provide any suggestions. I'm new to jujutsu so I'm sure people have workflows I couldn't even dream of.  
+Please provide any suggestions. I'm new to jujutsu so I'm sure people have workflows I couldn't even dream of.
 ## Installing
 `linux`: Grab the latest release. It's statically linked and should work on any linux machine.
 `mac`: Grab a prebuild. Let me know if you have any issues as I can't test on a mac.
 
-To open a shell with jj_tui on nix:`nix shell github:faldor20/jj_tui``
+To open a shell with jj_tui on nix: `nix shell github:faldor20/jj_tui`
 
 ## Dependencies
 The jujutsu CLI (minimum version 0.30.0)
 I haven't tested on windows or Mac.
-I believe it won't work outside Unix so Windows users will currently have to use wsl. 
+I believe it won't work outside Unix so Windows users will currently have to use wsl.
 
 
 # Config file:
@@ -46,13 +47,13 @@ key_map:
       title: "Squash"
       sub:
         # sub menu command
-        s: "squash_into_parent" 
+        s: "squash_into_parent"
 # If the terminal is smaller than this width, the UI will change to a single pane view
 single_pane_width_threshold: 110
 ```
 For a full list of commands ids see [`jj_tui/bin/graph_commands.ml`](jj_tui/bin/graph_commands.ml) and [`jj_tui/bin/file_commands.ml`](jj_tui/bin/file_commands.ml)
 
-# logs: 
+# logs:
 `linux`: $XDG_STATE_HOME/jj_tui/
 `macos`: ~/Library/logs/jj_tui/
 

--- a/jj_tui/bin/jj_commands.ml
+++ b/jj_tui/bin/jj_commands.ml
@@ -138,9 +138,17 @@ module Intern (Vars : Global_vars.Vars) = struct
            | Cmd_async _ )
        ; sort_key = _
        } ->
-         [ render_command_line ~indent_level (key_to_string key) description ]
+         let key_str =
+           let s = key_to_string key in
+           if s = " " then "<space>" else s
+         in
+         [ render_command_line ~indent_level key_str description ]
        | { key; description; cmd = SubCmd subs; sort_key = _ } ->
-         render_command_line ~indent_level (key_to_string key) description
+         let key_str =
+           let s = key_to_string key in
+           if s = " " then "<space>" else s
+         in
+         render_command_line ~indent_level key_str description
          :: render_commands ~indent_level:(indent_level + 1) subs
   ;;
 
@@ -148,7 +156,10 @@ module Intern (Vars : Global_vars.Vars) = struct
     let move_command =
       render_command_line ~indent_level:0 "Arrows" "navigation between windows"
     in
-    ((commands |> render_commands) @ if include_arrows then [ move_command ] else [])
+    let space_command =
+      render_command_line ~indent_level:0 "<space>" "toggle selection (multi-select)"
+    in
+    ((commands |> render_commands) @ if include_arrows then [ move_command; space_command ] else [])
     |> I.vcat
     |> Ui.atom
     |> Lwd.pure


### PR DESCRIPTION
Appreciate you creating this tool, it’s been super useful. While working with it, I was curious if there’s an option to select multiple revsets and perform actions on them. After digging into the code, I noticed there’s an undocumented feature tied to the <space> key, which wasn’t mentioned in the readme or help menu. I figured adding this might be beneficial, especially for new users.

changes:
* Add <space> key in help
* Readme also got updated from autosave/autoformatting(trimming out some whitespaces)